### PR TITLE
Bungee support

### DIFF
--- a/plugin/bukkit/src/main/java/broccolai/tickets/bukkit/listeners/BungeeListener.java
+++ b/plugin/bukkit/src/main/java/broccolai/tickets/bukkit/listeners/BungeeListener.java
@@ -1,0 +1,86 @@
+package broccolai.tickets.bukkit.listeners;
+
+import broccolai.tickets.api.model.ticket.Ticket;
+import broccolai.tickets.api.service.message.MessageService;
+import broccolai.tickets.api.service.ticket.TicketService;
+import broccolai.tickets.api.service.user.UserService;
+import com.google.common.io.ByteArrayDataInput;
+import com.google.common.io.ByteStreams;
+import net.kyori.adventure.text.Component;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.messaging.PluginMessageListener;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
+
+import javax.inject.Inject;
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.util.Optional;
+
+@SuppressWarnings("UnstableApiUsage")
+public final class BungeeListener implements PluginMessageListener {
+
+    private final TicketService ticketService;
+    private final UserService userService;
+    private final MessageService messageService;
+
+    @Inject
+    public BungeeListener(
+            final @NonNull TicketService ticketService,
+            final @NonNull UserService userService,
+            final @NonNull MessageService messageService
+    ) {
+        this.ticketService = ticketService;
+        this.userService = userService;
+        this.messageService = messageService;
+    }
+
+    @Override
+    public void onPluginMessageReceived(
+            final @NotNull String channel,
+            final @NotNull Player player,
+            final byte @NotNull [] message
+    ) {
+        if (!channel.equals("BungeeCord")) {
+            return;
+        }
+
+        ByteArrayDataInput in = ByteStreams.newDataInput(message);
+        String subchannel = in.readUTF();
+
+        if (!subchannel.equals("Tickets")) {
+            return;
+        }
+
+        short length = in.readShort();
+        byte[] messageBytes = new byte[length];
+        in.readFully(messageBytes);
+
+        DataInputStream messageIn = new DataInputStream(new ByteArrayInputStream(messageBytes));
+
+        int id;
+
+        try {
+            id = messageIn.readInt();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        Optional<Ticket> potentialTicket = ticketService.get(id);
+
+        if (!potentialTicket.isPresent()) {
+            return;
+        }
+
+        Ticket ticket = potentialTicket.get();
+
+        Component component = messageService.staffTicketCreate(ticket);
+
+        this.userService.players().forEach(soul -> {
+            if (soul.permission("tickets.staff.announce")) {
+                soul.sendMessage(component);
+            }
+        });
+    }
+
+}

--- a/plugin/bukkit/src/main/java/broccolai/tickets/bukkit/listeners/BungeeListener.java
+++ b/plugin/bukkit/src/main/java/broccolai/tickets/bukkit/listeners/BungeeListener.java
@@ -66,7 +66,7 @@ public final class BungeeListener implements PluginMessageListener {
             throw new RuntimeException(e);
         }
 
-        Optional<Ticket> potentialTicket = ticketService.get(id);
+        Optional<Ticket> potentialTicket = this.ticketService.get(id);
 
         if (!potentialTicket.isPresent()) {
             return;
@@ -74,7 +74,7 @@ public final class BungeeListener implements PluginMessageListener {
 
         Ticket ticket = potentialTicket.get();
 
-        Component component = messageService.staffTicketCreate(ticket);
+        Component component = this.messageService.staffTicketCreate(ticket);
 
         this.userService.players().forEach(soul -> {
             if (soul.permission("tickets.staff.announce")) {

--- a/plugin/bukkit/src/main/java/broccolai/tickets/bukkit/subscriptions/TicketSubscriber.java
+++ b/plugin/bukkit/src/main/java/broccolai/tickets/bukkit/subscriptions/TicketSubscriber.java
@@ -1,0 +1,63 @@
+package broccolai.tickets.bukkit.subscriptions;
+
+import broccolai.tickets.api.model.event.Subscriber;
+import broccolai.tickets.api.model.event.impl.TicketCreateEvent;
+import broccolai.tickets.api.service.event.EventService;
+import com.google.common.collect.Iterables;
+import com.google.common.io.ByteArrayDataOutput;
+import com.google.common.io.ByteStreams;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+import javax.inject.Inject;
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+@SuppressWarnings("UnstableApiUsage")
+public final class TicketSubscriber implements Subscriber {
+
+    private final Plugin plugin;
+
+    @Inject
+    public TicketSubscriber(final @NonNull Plugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public void register(@NonNull final EventService eventService) {
+
+    }
+
+    private void onTicketCreate(final @NonNull TicketCreateEvent event) {
+        ByteArrayDataOutput out = ByteStreams.newDataOutput();
+
+        out.writeUTF("Forward");
+        out.writeUTF("ONLINE");
+        out.writeUTF("Tickets");
+
+        ByteArrayOutputStream messageBytes = new ByteArrayOutputStream();
+        DataOutputStream messageOut = new DataOutputStream(messageBytes);
+
+        try {
+            messageOut.writeInt(event.ticket().id());
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        out.writeShort(messageBytes.toByteArray().length);
+        out.write(messageBytes.toByteArray());
+
+        Player player = Iterables.getFirst(Bukkit.getOnlinePlayers(), null);
+
+        if (player == null) {
+            // theoretically shouldn't happen
+            return;
+        }
+
+        player.sendPluginMessage(this.plugin, "BungeeCord", out.toByteArray());
+    }
+
+}


### PR DESCRIPTION
todo:

add more than just ticket create event forwarding
stop queuing interactions for saving so that they can be sent
add a has been forwarded boolean to notification event so that it can be resent without causing a loop

maybe:

abstract this out into core