### PR TITLE
Run JdbiExtension once for every test class

### DIFF
--- a/core/src/test/java/love/broccolai/tickets/core/service/DatabaseStorageServiceTest.java
+++ b/core/src/test/java/love/broccolai/tickets/core/service/DatabaseStorageServiceTest.java
@@ -25,7 +25,7 @@ class DatabaseStorageServiceTest {
 
     @BeforeEach
     void setupEach() {
-        this.storageService = new DatabaseStorageService(h2Extension.getJdbi());
+        this.storageService = new DatabaseStorageService(this.h2Extension.getJdbi());
     }
 
     @Test

--- a/core/src/test/java/love/broccolai/tickets/core/service/DatabaseStorageServiceTest.java
+++ b/core/src/test/java/love/broccolai/tickets/core/service/DatabaseStorageServiceTest.java
@@ -19,13 +19,13 @@ import static com.google.common.truth.Truth.assertThat;
 class DatabaseStorageServiceTest {
 
     @RegisterExtension
-    private static final JdbiExtension H2_EXTENSION = TicketsH2Extension.instance();
+    private final JdbiExtension h2Extension = TicketsH2Extension.instance();
 
     private StorageService storageService;
 
     @BeforeEach
     void setupEach() {
-        this.storageService = new DatabaseStorageService(H2_EXTENSION.getJdbi());
+        this.storageService = new DatabaseStorageService(h2Extension.getJdbi());
     }
 
     @Test


### PR DESCRIPTION
The JdbiExtension should not be registered as a class but as an instance field.

Fixes jdbi/jdbi#2208